### PR TITLE
Fix "None" keypress showing up as "N"

### DIFF
--- a/src/MainPage.cs
+++ b/src/MainPage.cs
@@ -135,9 +135,11 @@ namespace GuessWord
 			// kb.Triggers.Add(new KeyboardBehaviorTrigger{ Keys = });
 
 			kb.KeyUp += async (s, e)=>{
-				Console.WriteLine($"KeyUp: {e.Keys.ToString()}");
+				var key = e.Keys.ToString();
+				Console.WriteLine($"KeyUp: {key}");
+				
 				char letter = Char.ToUpper(e.KeyChar);
-				if ((letter >= 'A' && letter <= 'Z'))
+				if ((letter >= 'A' && letter <= 'Z') && key != "None")
 				{
 					if (!guessedLetters.Contains(letter))
 					{


### PR DESCRIPTION
When you press a non-key, like spacebar, it incorrectly counts as a guess for "N" as it comes back as "None", this fixes this issue, it could potentially be localised so might not be a real fix!